### PR TITLE
Add responsive media queries (#10)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>Meeting Minutes</title>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Simple meeting minutes page">
     <link rel="icon" href="favicon.ico">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/style.css
+++ b/style.css
@@ -203,3 +203,42 @@ nav {
     }
   }
 }
+
+@media (max-width: 768px) {
+  nav {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  main {
+    width: 95%;
+  }
+
+  h1 {
+    font-size: 1.5em;
+  }
+}
+
+@media (max-width: 480px) {
+  header {
+    padding: 10px 12px 10px 12px;
+  }
+
+  h1 {
+    font-size: 1.2em;
+  }
+
+  .back-to-top {
+    padding: 6px 10px;
+    font-size: 0.85rem;
+  }
+
+  body {
+    padding: 0 0.5rem;
+  }
+}


### PR DESCRIPTION
- Add viewport meta tag in HTML
- Media query at 768px for tablet: stack nav, single-column grid, wider main
- Media query at 480px for phone: smaller header padding, smaller h1, compact back-to-top